### PR TITLE
Add --invoice-macaroon-file option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ pub struct Config {
     cert_file: Option<String>,
     #[clap(long)]
     /// Path to admin.macaroon file for lnd
-    admin_macaroon_file: Option<String>,
+    macaroon_file: Option<String>,
     #[clap(long)]
     /// Path to invoice.macaroon file for lnd
     invoice_macaroon_file: Option<String>,
@@ -45,7 +45,7 @@ impl Config {
         match self.invoice_macaroon_file {
             Some(_) => self.invoice_macaroon_file.clone().unwrap(),
             None => self
-                .admin_macaroon_file
+                .macaroon_file
                 .clone()
                 .unwrap_or_else(|| default_macaroon_file(&self.network)),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,9 @@ pub struct Config {
 
 impl Config {
     pub fn macaroon_file(&self) -> String {
+        if self.macaroon_file.is_some() && self.invoice_macaroon_file.is_some() {
+            panic!("cannot set --macaroon-file and --invoice-macaroon-file at the same time")
+        }
         match self.invoice_macaroon_file {
             Some(_) => self.invoice_macaroon_file.clone().unwrap(),
             None => self

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,10 @@ pub struct Config {
     cert_file: Option<String>,
     #[clap(long)]
     /// Path to admin.macaroon file for lnd
-    macaroon_file: Option<String>,
+    admin_macaroon_file: Option<String>,
+    #[clap(long)]
+    /// Path to invoice.macaroon file for lnd
+    invoice_macaroon_file: Option<String>,
     #[clap(long)]
     /// Include route hints in invoices
     pub route_hints: bool,
@@ -39,9 +42,20 @@ pub struct Config {
 
 impl Config {
     pub fn macaroon_file(&self) -> String {
-        self.macaroon_file
-            .clone()
-            .unwrap_or_else(|| default_macaroon_file(&self.network))
+        match self.invoice_macaroon_file {
+            Some(_) => self.invoice_macaroon_file.clone().unwrap(),
+            None => self
+                .admin_macaroon_file
+                .clone()
+                .unwrap_or_else(|| default_macaroon_file(&self.network)),
+        }
+    }
+
+    pub fn recv_only(&self) -> bool {
+        match self.invoice_macaroon_file {
+            Some(_) => true,
+            None => false,
+        }
     }
 
     pub fn cert_file(&self) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,13 @@ const METHODS: [Method; 8] = [
     Method::MultiPayKeysend,
 ];
 
+const RECV_ONLY_METHODS: [Method; 4] = [
+    Method::GetInfo,
+    Method::MakeInvoice,
+    Method::GetBalance,
+    Method::LookupInvoice,
+];
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     pretty_env_logger::try_init()?;
@@ -59,13 +66,19 @@ async fn main() -> anyhow::Result<()> {
     .expect("failed to connect");
 
     let mut ln_client = lnd_client.lightning().clone();
-    let lnd_info: GetInfoResponse = ln_client
-        .get_info(GetInfoRequest {})
-        .await
-        .expect("Failed to get lnd info")
-        .into_inner();
 
-    info!("Connected to lnd: {}", lnd_info.identity_pubkey);
+    if !config.recv_only() {
+        // can only read info with admin.macaroon
+        let lnd_info: GetInfoResponse = ln_client
+            .get_info(GetInfoRequest {})
+            .await
+            .expect("Failed to get lnd info")
+            .into_inner();
+
+        info!("Connected to lnd: {}", lnd_info.identity_pubkey);
+    } else {
+        info!("Connected to lnd")
+    }
 
     let uri = NostrWalletConnectURI::new(
         keys.server_keys().public_key(),
@@ -146,6 +159,7 @@ async fn event_loop(
         if !keys.sent_info {
             let content: String = METHODS
                 .iter()
+                .filter(|i| !config.recv_only() || RECV_ONLY_METHODS.contains(i))
                 .map(|i| i.to_string())
                 .collect::<Vec<_>>()
                 .join(" ");
@@ -312,240 +326,264 @@ async fn handle_nwc_params(
     mut lnd: LndLightningClient,
 ) -> anyhow::Result<()> {
     let mut d_tag: Option<Tag> = None;
-    let content = match params {
-        RequestParams::PayInvoice(params) => {
-            d_tag = params.id.map(Tag::Identifier);
 
-            let invoice = Bolt11Invoice::from_str(&params.invoice)
-                .map_err(|_| anyhow!("Failed to parse invoice"))?;
-            let msats = invoice
-                .amount_milli_satoshis()
-                .or(params.amount)
-                .unwrap_or(0);
+    let content;
+    if config.recv_only() && !RECV_ONLY_METHODS.contains(&method) {
+        content = Response {
+            result_type: method,
+            error: Some(NIP47Error {
+                code: ErrorCode::Restricted,
+                message: "Method not allowed.".to_string(),
+            }),
+            result: None,
+        };
+    } else {
+        content = match params {
+            RequestParams::PayInvoice(params) => {
+                d_tag = params.id.map(Tag::Identifier);
 
-            let error_msg = if config.max_amount > 0 && msats > config.max_amount * 1_000 {
-                Some("Invoice amount too high.")
-            } else if config.daily_limit > 0
-                && tracker.lock().await.sum_payments() + msats > config.daily_limit * 1_000
-            {
-                Some("Daily limit exceeded.")
-            } else {
-                None
-            };
+                let invoice = Bolt11Invoice::from_str(&params.invoice)
+                    .map_err(|_| anyhow!("Failed to parse invoice"))?;
+                let msats = invoice
+                    .amount_milli_satoshis()
+                    .or(params.amount)
+                    .unwrap_or(0);
 
-            // verify amount, convert to msats
-            match error_msg {
-                None => {
-                    match pay_invoice(invoice, lnd, method).await {
-                        Ok(content) => {
-                            // add payment to tracker
-                            tracker.lock().await.add_payment(msats);
-                            content
-                        }
-                        Err(e) => {
-                            error!("Error paying invoice: {e}");
+                let error_msg = if config.max_amount > 0 && msats > config.max_amount * 1_000 {
+                    Some("Invoice amount too high.")
+                } else if config.daily_limit > 0
+                    && tracker.lock().await.sum_payments() + msats > config.daily_limit * 1_000
+                {
+                    Some("Daily limit exceeded.")
+                } else {
+                    None
+                };
 
-                            Response {
-                                result_type: method,
-                                error: Some(NIP47Error {
-                                    code: ErrorCode::InsufficientBalance,
-                                    message: format!("Failed to pay invoice: {e}"),
-                                }),
-                                result: None,
+                // verify amount, convert to msats
+                match error_msg {
+                    None => {
+                        match pay_invoice(invoice, lnd, method).await {
+                            Ok(content) => {
+                                // add payment to tracker
+                                tracker.lock().await.add_payment(msats);
+                                content
+                            }
+                            Err(e) => {
+                                error!("Error paying invoice: {e}");
+
+                                Response {
+                                    result_type: method,
+                                    error: Some(NIP47Error {
+                                        code: ErrorCode::InsufficientBalance,
+                                        message: format!("Failed to pay invoice: {e}"),
+                                    }),
+                                    result: None,
+                                }
                             }
                         }
                     }
+                    Some(err_msg) => Response {
+                        result_type: method,
+                        error: Some(NIP47Error {
+                            code: ErrorCode::QuotaExceeded,
+                            message: err_msg.to_string(),
+                        }),
+                        result: None,
+                    },
                 }
-                Some(err_msg) => Response {
-                    result_type: method,
-                    error: Some(NIP47Error {
-                        code: ErrorCode::QuotaExceeded,
-                        message: err_msg.to_string(),
-                    }),
-                    result: None,
-                },
             }
-        }
-        RequestParams::PayKeysend(params) => {
-            d_tag = params.id.map(Tag::Identifier);
+            RequestParams::PayKeysend(params) => {
+                d_tag = params.id.map(Tag::Identifier);
 
-            let msats = params.amount;
-            let error_msg = if config.max_amount > 0 && msats > config.max_amount * 1_000 {
-                Some("Invoice amount too high.")
-            } else if config.daily_limit > 0
-                && tracker.lock().await.sum_payments() + msats > config.daily_limit * 1_000
-            {
-                Some("Daily limit exceeded.")
-            } else {
-                None
-            };
+                let msats = params.amount;
+                let error_msg = if config.max_amount > 0 && msats > config.max_amount * 1_000 {
+                    Some("Invoice amount too high.")
+                } else if config.daily_limit > 0
+                    && tracker.lock().await.sum_payments() + msats > config.daily_limit * 1_000
+                {
+                    Some("Daily limit exceeded.")
+                } else {
+                    None
+                };
 
-            // verify amount, convert to msats
-            match error_msg {
-                None => {
-                    let pubkey = bitcoin::secp256k1::PublicKey::from_str(&params.pubkey)?;
-                    match pay_keysend(
-                        pubkey,
-                        params.preimage,
-                        params.tlv_records,
-                        msats,
-                        lnd,
-                        method,
-                    )
-                    .await
-                    {
-                        Ok(content) => {
-                            // add payment to tracker
-                            tracker.lock().await.add_payment(msats);
-                            content
-                        }
-                        Err(e) => {
-                            error!("Error paying keysend: {e}");
+                // verify amount, convert to msats
+                match error_msg {
+                    None => {
+                        let pubkey = bitcoin::secp256k1::PublicKey::from_str(&params.pubkey)?;
+                        match pay_keysend(
+                            pubkey,
+                            params.preimage,
+                            params.tlv_records,
+                            msats,
+                            lnd,
+                            method,
+                        )
+                        .await
+                        {
+                            Ok(content) => {
+                                // add payment to tracker
+                                tracker.lock().await.add_payment(msats);
+                                content
+                            }
+                            Err(e) => {
+                                error!("Error paying keysend: {e}");
 
-                            Response {
-                                result_type: method,
-                                error: Some(NIP47Error {
-                                    code: ErrorCode::PaymentFailed,
-                                    message: format!("Failed to pay keysend: {e}"),
-                                }),
-                                result: None,
+                                Response {
+                                    result_type: method,
+                                    error: Some(NIP47Error {
+                                        code: ErrorCode::PaymentFailed,
+                                        message: format!("Failed to pay keysend: {e}"),
+                                    }),
+                                    result: None,
+                                }
                             }
                         }
                     }
+                    Some(err_msg) => Response {
+                        result_type: method,
+                        error: Some(NIP47Error {
+                            code: ErrorCode::QuotaExceeded,
+                            message: err_msg.to_string(),
+                        }),
+                        result: None,
+                    },
                 }
-                Some(err_msg) => Response {
-                    result_type: method,
-                    error: Some(NIP47Error {
-                        code: ErrorCode::QuotaExceeded,
-                        message: err_msg.to_string(),
-                    }),
-                    result: None,
-                },
             }
-        }
-        RequestParams::MakeInvoice(params) => {
-            let description_hash: Vec<u8> = match params.description_hash {
-                None => vec![],
-                Some(str) => FromHex::from_hex(&str)?,
-            };
-            let inv = Invoice {
-                memo: params.description.unwrap_or_default(),
-                description_hash,
-                value_msat: params.amount as i64,
-                expiry: params.expiry.unwrap_or(86_400) as i64,
-                private: config.route_hints,
-                ..Default::default()
-            };
-            let res = lnd.add_invoice(inv).await?.into_inner();
-
-            info!("Created invoice: {}", res.payment_request);
-
-            Response {
-                result_type: method,
-                error: None,
-                result: Some(ResponseResult::MakeInvoice(MakeInvoiceResponseResult {
-                    invoice: res.payment_request,
-                    payment_hash: ::hex::encode(res.r_hash),
-                })),
-            }
-        }
-        RequestParams::LookupInvoice(params) => {
-            let mut invoice: Option<Bolt11Invoice> = None;
-            let payment_hash: Vec<u8> = match params.payment_hash {
-                None => match params.invoice {
-                    None => return Err(anyhow!("Missing payment_hash or invoice")),
-                    Some(bolt11) => {
-                        let inv = Bolt11Invoice::from_str(&bolt11)
-                            .map_err(|_| anyhow!("Failed to parse invoice"))?;
-                        invoice = Some(inv.clone());
-                        inv.payment_hash().into_32().to_vec()
-                    }
-                },
-                Some(str) => FromHex::from_hex(&str)?,
-            };
-
-            let res = lnd
-                .lookup_invoice(PaymentHash {
-                    r_hash: payment_hash.clone(),
-                    ..Default::default()
-                })
-                .await?
-                .into_inner();
-
-            info!("Looked up invoice: {}", res.payment_request);
-
-            let (description, description_hash) = match invoice {
-                Some(inv) => match inv.description() {
-                    Bolt11InvoiceDescription::Direct(desc) => (Some(desc.to_string()), None),
-                    Bolt11InvoiceDescription::Hash(hash) => (None, Some(hash.0.to_string())),
-                },
-                None => (None, None),
-            };
-
-            let preimage = if res.r_preimage.is_empty() {
-                None
-            } else {
-                Some(hex::encode(res.r_preimage))
-            };
-
-            let settled_at = if res.settle_date == 0 {
-                None
-            } else {
-                Some(res.settle_date as u64)
-            };
-
-            Response {
-                result_type: method,
-                error: None,
-                result: Some(ResponseResult::LookupInvoice(LookupInvoiceResponseResult {
-                    transaction_type: None,
-                    invoice: Some(res.payment_request),
-                    description,
+            RequestParams::MakeInvoice(params) => {
+                let description_hash: Vec<u8> = match params.description_hash {
+                    None => vec![],
+                    Some(str) => FromHex::from_hex(&str)?,
+                };
+                let inv = Invoice {
+                    memo: params.description.unwrap_or_default(),
                     description_hash,
-                    preimage,
-                    payment_hash: hex::encode(payment_hash),
-                    amount: res.value_msat as u64,
-                    fees_paid: 0,
-                    created_at: res.creation_date as u64,
-                    expires_at: (res.creation_date + res.expiry) as u64,
-                    settled_at,
-                    metadata: Default::default(),
-                })),
+                    value_msat: params.amount as i64,
+                    expiry: params.expiry.unwrap_or(86_400) as i64,
+                    private: config.route_hints,
+                    ..Default::default()
+                };
+                let res = lnd.add_invoice(inv).await?.into_inner();
+
+                info!("Created invoice: {}", res.payment_request);
+
+                Response {
+                    result_type: method,
+                    error: None,
+                    result: Some(ResponseResult::MakeInvoice(MakeInvoiceResponseResult {
+                        invoice: res.payment_request,
+                        payment_hash: ::hex::encode(res.r_hash),
+                    })),
+                }
+            }
+            RequestParams::LookupInvoice(params) => {
+                let mut invoice: Option<Bolt11Invoice> = None;
+                let payment_hash: Vec<u8> = match params.payment_hash {
+                    None => match params.invoice {
+                        None => return Err(anyhow!("Missing payment_hash or invoice")),
+                        Some(bolt11) => {
+                            let inv = Bolt11Invoice::from_str(&bolt11)
+                                .map_err(|_| anyhow!("Failed to parse invoice"))?;
+                            invoice = Some(inv.clone());
+                            inv.payment_hash().into_32().to_vec()
+                        }
+                    },
+                    Some(str) => FromHex::from_hex(&str)?,
+                };
+
+                let res = lnd
+                    .lookup_invoice(PaymentHash {
+                        r_hash: payment_hash.clone(),
+                        ..Default::default()
+                    })
+                    .await?
+                    .into_inner();
+
+                info!("Looked up invoice: {}", res.payment_request);
+
+                let (description, description_hash) = match invoice {
+                    Some(inv) => match inv.description() {
+                        Bolt11InvoiceDescription::Direct(desc) => (Some(desc.to_string()), None),
+                        Bolt11InvoiceDescription::Hash(hash) => (None, Some(hash.0.to_string())),
+                    },
+                    None => (None, None),
+                };
+
+                let preimage = if res.r_preimage.is_empty() {
+                    None
+                } else {
+                    Some(hex::encode(res.r_preimage))
+                };
+
+                let settled_at = if res.settle_date == 0 {
+                    None
+                } else {
+                    Some(res.settle_date as u64)
+                };
+
+                Response {
+                    result_type: method,
+                    error: None,
+                    result: Some(ResponseResult::LookupInvoice(LookupInvoiceResponseResult {
+                        transaction_type: None,
+                        invoice: Some(res.payment_request),
+                        description,
+                        description_hash,
+                        preimage,
+                        payment_hash: hex::encode(payment_hash),
+                        amount: res.value_msat as u64,
+                        fees_paid: 0,
+                        created_at: res.creation_date as u64,
+                        expires_at: (res.creation_date + res.expiry) as u64,
+                        settled_at,
+                        metadata: Default::default(),
+                    })),
+                }
+            }
+            RequestParams::GetBalance => {
+                let tracker = tracker.lock().await.sum_payments();
+                let remaining_msats = config.daily_limit * 1_000 - tracker;
+                info!("Current balance: {remaining_msats}msats");
+                Response {
+                    result_type: method,
+                    error: None,
+                    result: Some(ResponseResult::GetBalance(GetBalanceResponseResult {
+                        balance: remaining_msats,
+                    })),
+                }
+            }
+            RequestParams::GetInfo => {
+                let lnd_info = match config.recv_only() {
+                    true => None,
+                    false => Some(lnd.get_info(GetInfoRequest {}).await?.into_inner()),
+                };
+                info!("Getting info");
+                Response {
+                    result_type: method,
+                    error: None,
+                    result: Some(ResponseResult::GetInfo(GetInfoResponseResult {
+                        alias: lnd_info.clone().map_or("".to_string(), |info| info.alias),
+                        color: lnd_info.clone().map_or("".to_string(), |info| info.color),
+                        pubkey: lnd_info
+                            .clone()
+                            .map_or("".to_string(), |info| info.identity_pubkey),
+                        network: "".to_string(),
+                        block_height: lnd_info.clone().map_or(0, |info| info.block_height),
+                        block_hash: lnd_info
+                            .clone()
+                            .map_or("".to_string(), |info| info.block_hash),
+                        methods: METHODS
+                            .iter()
+                            .filter(|i| !config.recv_only() || RECV_ONLY_METHODS.contains(i))
+                            .map(|i| i.to_string())
+                            .collect(),
+                    })),
+                }
+            }
+            _ => {
+                return Err(anyhow!("Command not supported"));
             }
         }
-        RequestParams::GetBalance => {
-            let tracker = tracker.lock().await.sum_payments();
-            let remaining_msats = config.daily_limit * 1_000 - tracker;
-            info!("Current balance: {remaining_msats}msats");
-            Response {
-                result_type: method,
-                error: None,
-                result: Some(ResponseResult::GetBalance(GetBalanceResponseResult {
-                    balance: remaining_msats,
-                })),
-            }
-        }
-        RequestParams::GetInfo => {
-            let lnd_info: GetInfoResponse = lnd.get_info(GetInfoRequest {}).await?.into_inner();
-            info!("Getting info");
-            Response {
-                result_type: method,
-                error: None,
-                result: Some(ResponseResult::GetInfo(GetInfoResponseResult {
-                    alias: lnd_info.alias,
-                    color: lnd_info.color,
-                    pubkey: lnd_info.identity_pubkey,
-                    network: "".to_string(),
-                    block_height: lnd_info.block_height,
-                    block_hash: lnd_info.block_hash,
-                    methods: METHODS.iter().map(|i| i.to_string()).collect(),
-                })),
-            }
-        }
-        _ => {
-            return Err(anyhow!("Command not supported"));
-        }
-    };
+    }
 
     let encrypted = nip04::encrypt(
         &keys.server_key.into(),


### PR DESCRIPTION
This PR adds `--invoice-macaroon-file` which can be used to create a NWC connection that only supports `get_info`, `make_invoice`, `get_balance`, `lookup_invoice`.

I know this code is probably shit since it's my first time writing a non-trivial amount of rust code but I wanted to let you decide if you're interested in this enough to merge or refine it. It's not backwards compatible though since I renamed `--macaroon-file` to `--admin-macaroon-file`.

 `--admin-macaroon-file` and `--invoice-macaroon-file` should also probably use exclusive OR. It currently favors `--invoice-macaroon-file`. I also only tested `get_info` and `make_invoice`.

We're using this at SN for local dev so we can attach NWC send+recv, see https://github.com/stackernews/stacker.news/pull/1442.

Feel free to close this if not interested, just wanted to offer giving this back :)
